### PR TITLE
fix: support Android 14 display power mode control

### DIFF
--- a/server/src/main/java/com/genymobile/scrcpy/Device.java
+++ b/server/src/main/java/com/genymobile/scrcpy/Device.java
@@ -2,6 +2,7 @@ package com.genymobile.scrcpy;
 
 import com.genymobile.scrcpy.wrappers.ClipboardManager;
 import com.genymobile.scrcpy.wrappers.ContentProvider;
+import com.genymobile.scrcpy.wrappers.DisplayControl;
 import com.genymobile.scrcpy.wrappers.InputManager;
 import com.genymobile.scrcpy.wrappers.ServiceManager;
 import com.genymobile.scrcpy.wrappers.SurfaceControl;
@@ -293,12 +294,47 @@ public final class Device {
      * @param mode one of the {@code POWER_MODE_*} constants
      */
     public static boolean setScreenPowerMode(int mode) {
+        // Android 14+ support: methods moved to DisplayControl
+        boolean useDisplayControl = Build.VERSION.SDK_INT >= 34 && !SurfaceControl.hasGetPhysicalDisplayIdsMethod();
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            // For Android 10+, try to change power mode for all physical displays
+            long[] physicalDisplayIds = null;
+
+            if (useDisplayControl && DisplayControl.isAvailable()) {
+                physicalDisplayIds = DisplayControl.getPhysicalDisplayIds();
+            } else if (SurfaceControl.hasGetPhysicalDisplayIdsMethod()) {
+                physicalDisplayIds = SurfaceControl.getPhysicalDisplayIds();
+            }
+
+            if (physicalDisplayIds != null) {
+                boolean allOk = true;
+                for (long physicalDisplayId : physicalDisplayIds) {
+                    IBinder binder = useDisplayControl && DisplayControl.isAvailable()
+                            ? DisplayControl.getPhysicalDisplayToken(physicalDisplayId)
+                            : SurfaceControl.getPhysicalDisplayToken(physicalDisplayId);
+                    if (binder != null) {
+                        allOk &= SurfaceControl.setDisplayPowerMode(binder, mode);
+                    }
+                }
+                if (allOk) {
+                    Ln.i("Device screen turned " + (mode == POWER_MODE_OFF ? "off" : "on"));
+                    return true;
+                }
+            }
+        }
+
+        // Fallback for older Android versions or if the above method failed
         IBinder d = SurfaceControl.getBuiltInDisplay();
         if (d == null) {
             Ln.e("Could not get built-in display");
             return false;
         }
-        return SurfaceControl.setDisplayPowerMode(d, mode);
+        boolean ok = SurfaceControl.setDisplayPowerMode(d, mode);
+        if (ok) {
+            Ln.i("Device screen turned " + (mode == POWER_MODE_OFF ? "off" : "on"));
+        }
+        return ok;
     }
 
     public static boolean powerOffScreen(int displayId) {

--- a/server/src/main/java/com/genymobile/scrcpy/wrappers/DisplayControl.java
+++ b/server/src/main/java/com/genymobile/scrcpy/wrappers/DisplayControl.java
@@ -1,0 +1,85 @@
+package com.genymobile.scrcpy.wrappers;
+
+import com.genymobile.scrcpy.Ln;
+
+import android.annotation.SuppressLint;
+import android.os.IBinder;
+import android.os.Build;
+import android.system.Os;
+
+import java.lang.reflect.Method;
+
+@SuppressLint({"PrivateApi", "SoonBlockedPrivateApi", "BlockedPrivateApi"})
+public final class DisplayControl {
+
+    private static final Class<?> CLASS;
+
+    static {
+        Class<?> displayControlClass = null;
+        if (Build.VERSION.SDK_INT >= 34) {
+            try {
+                Class<?> classLoaderFactoryClass = Class.forName("com.android.internal.os.ClassLoaderFactory");
+                Method createClassLoaderMethod = classLoaderFactoryClass.getDeclaredMethod("createClassLoader", String.class, String.class, String.class,
+                        ClassLoader.class, int.class, boolean.class, String.class);
+
+                String systemServerClasspath = Os.getenv("SYSTEMSERVERCLASSPATH");
+                ClassLoader classLoader = (ClassLoader) createClassLoaderMethod.invoke(null, systemServerClasspath, null, null,
+                        ClassLoader.getSystemClassLoader(), 0, true, null);
+
+                displayControlClass = classLoader.loadClass("com.android.server.display.DisplayControl");
+
+                Method loadMethod = Runtime.class.getDeclaredMethod("loadLibrary0", Class.class, String.class);
+                loadMethod.setAccessible(true);
+                loadMethod.invoke(Runtime.getRuntime(), displayControlClass, "android_servers");
+            } catch (Throwable e) {
+                Ln.e("Could not initialize DisplayControl", e);
+            }
+        }
+        CLASS = displayControlClass;
+    }
+
+    private static Method getPhysicalDisplayTokenMethod;
+    private static Method getPhysicalDisplayIdsMethod;
+
+    private DisplayControl() {
+        // only static methods
+    }
+
+    public static boolean isAvailable() {
+        return CLASS != null;
+    }
+
+    private static Method getGetPhysicalDisplayTokenMethod() throws NoSuchMethodException {
+        if (getPhysicalDisplayTokenMethod == null) {
+            getPhysicalDisplayTokenMethod = CLASS.getMethod("getPhysicalDisplayToken", long.class);
+        }
+        return getPhysicalDisplayTokenMethod;
+    }
+
+    public static IBinder getPhysicalDisplayToken(long physicalDisplayId) {
+        try {
+            Method method = getGetPhysicalDisplayTokenMethod();
+            return (IBinder) method.invoke(null, physicalDisplayId);
+        } catch (ReflectiveOperationException e) {
+            Ln.e("Could not invoke method", e);
+            return null;
+        }
+    }
+
+    private static Method getGetPhysicalDisplayIdsMethod() throws NoSuchMethodException {
+        if (getPhysicalDisplayIdsMethod == null) {
+            getPhysicalDisplayIdsMethod = CLASS.getMethod("getPhysicalDisplayIds");
+        }
+        return getPhysicalDisplayIdsMethod;
+    }
+
+    public static long[] getPhysicalDisplayIds() {
+        try {
+            Method method = getGetPhysicalDisplayIdsMethod();
+            return (long[]) method.invoke(null);
+        } catch (ReflectiveOperationException e) {
+            Ln.e("Could not invoke method", e);
+            return null;
+        }
+    }
+}

--- a/server/src/main/java/com/genymobile/scrcpy/wrappers/SurfaceControl.java
+++ b/server/src/main/java/com/genymobile/scrcpy/wrappers/SurfaceControl.java
@@ -29,6 +29,8 @@ public final class SurfaceControl {
 
     private static Method getBuiltInDisplayMethod;
     private static Method setDisplayPowerModeMethod;
+    private static Method getPhysicalDisplayTokenMethod;
+    private static Method getPhysicalDisplayIdsMethod;
 
     private SurfaceControl() {
         // only static methods
@@ -92,6 +94,15 @@ public final class SurfaceControl {
         return getBuiltInDisplayMethod;
     }
 
+    public static boolean hasGetBuildInDisplayMethod() {
+        try {
+            getGetBuiltInDisplayMethod();
+            return true;
+        } catch (NoSuchMethodException e) {
+            return false;
+        }
+    }
+
     public static IBinder getBuiltInDisplay() {
 
         try {
@@ -103,6 +114,49 @@ public final class SurfaceControl {
 
             // call getInternalDisplayToken()
             return (IBinder) method.invoke(null);
+        } catch (ReflectiveOperationException e) {
+            Ln.e("Could not invoke method", e);
+            return null;
+        }
+    }
+
+    private static Method getGetPhysicalDisplayTokenMethod() throws NoSuchMethodException {
+        if (getPhysicalDisplayTokenMethod == null) {
+            getPhysicalDisplayTokenMethod = CLASS.getMethod("getPhysicalDisplayToken", long.class);
+        }
+        return getPhysicalDisplayTokenMethod;
+    }
+
+    public static IBinder getPhysicalDisplayToken(long physicalDisplayId) {
+        try {
+            Method method = getGetPhysicalDisplayTokenMethod();
+            return (IBinder) method.invoke(null, physicalDisplayId);
+        } catch (ReflectiveOperationException e) {
+            Ln.e("Could not invoke method", e);
+            return null;
+        }
+    }
+
+    private static Method getGetPhysicalDisplayIdsMethod() throws NoSuchMethodException {
+        if (getPhysicalDisplayIdsMethod == null) {
+            getPhysicalDisplayIdsMethod = CLASS.getMethod("getPhysicalDisplayIds");
+        }
+        return getPhysicalDisplayIdsMethod;
+    }
+
+    public static boolean hasGetPhysicalDisplayIdsMethod() {
+        try {
+            getGetPhysicalDisplayIdsMethod();
+            return true;
+        } catch (NoSuchMethodException e) {
+            return false;
+        }
+    }
+
+    public static long[] getPhysicalDisplayIds() {
+        try {
+            Method method = getGetPhysicalDisplayIdsMethod();
+            return (long[]) method.invoke(null);
         } catch (ReflectiveOperationException e) {
             Ln.e("Could not invoke method", e);
             return null;


### PR DESCRIPTION
## Problem

On Android 14, calling `setScreenPowerMode()` throws:
```
NoSuchMethodException: android.view.SurfaceControl.getInternalDisplayToken []
```

This is because the internal display methods have been moved from `SurfaceControl` to `DisplayControl` class in Android 14.

## Solution

- Add `DisplayControl.java` wrapper for Android 14+ display APIs
- Add `getPhysicalDisplayIds()` and `getPhysicalDisplayToken()` to `SurfaceControl`
- Update `Device.setScreenPowerMode()` to:
  1. Use `DisplayControl` on Android 14+ when `SurfaceControl.getPhysicalDisplayIds` is not available
  2. Fall back to `SurfaceControl.getPhysicalDisplayIds` for Android 10-13
  3. Fall back to `getBuiltInDisplay()` for older versions

## Testing

Tested on Pixel 6 with Android 14. The screen power control button now works correctly.

## Related Issues

- https://github.com/NetrisTV/ws-scrcpy/issues/217
- https://github.com/Genymobile/scrcpy/issues/4823